### PR TITLE
Potential schema typo fix

### DIFF
--- a/templates/daily.schema.yml
+++ b/templates/daily.schema.yml
@@ -9,7 +9,7 @@ schemas:
 - id: journal
   title: journal
   desc: ""
-  parent: root
+  parent: daily
   children:
     - year
 - id: year


### PR DESCRIPTION
I think the second element in the schema needs to have a parent of the previous one, and not root, but I could be wrong.