### PR TITLE
Remove parent: root from journal id

### DIFF
--- a/templates/daily.schema.yml
+++ b/templates/daily.schema.yml
@@ -9,7 +9,6 @@ schemas:
 - id: journal
   title: journal
   desc: ""
-  parent: root
   children:
     - year
 - id: year


### PR DESCRIPTION
Parent: root present in two id's, creating issue with application of schema when example template was utilized.